### PR TITLE
Replace `asm!` macro with `llvm_asm!`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ environment:
           ABI: msvc
         - RUST: 1.22.1
           ABI: gnu
-        - RUST: 1.26.2
+        - RUST: 1.43.1
           ABI: msvc
-        - RUST: 1.26.2
+        - RUST: 1.43.1
           ABI: gnu
         - RUST: beta
           ABI: msvc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,9 @@
 //! }
 //! ```
 
-#![cfg_attr(extprim_channel="unstable", feature(asm, test, specialization, const_fn))]
+#![cfg_attr(extprim_channel="unstable", feature(llvm_asm, test, specialization, const_fn))]
 // feature requirement:
-//  - asm: to provide a fast implementation of u64_long_mul in x86_64
+//  - llvm_asm: to provide a fast implementation of u64_long_mul in x86_64
 //  - test: benchmarking
 //  - specialization: to allow ToExtraPrimitive inherit from ToPrimitive, while ensuring conversion
 //                    between the 128-bit types remain correct

--- a/src/u128.rs
+++ b/src/u128.rs
@@ -881,7 +881,7 @@ fn u64_long_mul(left: u64, right: u64) -> u128 {
 fn u64_long_mul(left: u64, right: u64) -> u128 {
     unsafe {
         let mut result: u128 = ::std::mem::uninitialized();
-        asm!("
+        llvm_asm!("
             movq $2, %rax
             mulq $3
             movq %rax, $0


### PR DESCRIPTION
It becomes a hard error in the latest nightly:
```
error: legacy asm! syntax is no longer supported
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/extprim-1.7.0/src/u128.rs:884:9
    |
884 |           asm!("
    |           ^---
    |           |
    |  _________help: replace with: `llvm_asm!`
    | |
885 | |             movq $2, %rax
886 | |             mulq $3
887 | |             movq %rax, $0
...   |
891 | |         : "r"(left), "r"(right)
892 | |         : "rax", "rdx");
    | |________________________^

error: aborting due to previous error
```

r? @kennytm 